### PR TITLE
feat: Drop support for ROS Eloquent

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,6 @@ jobs:
       matrix:
         ros-distro:
           - dashing
-          - eloquent
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64]
-        ros-distro: [dashing, eloquent]
+        ros-distro: [dashing]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
ROS Eloquent is no longer supported (EOL Nov. 2020).  
https://index.ros.org/doc/ros2/Releases/  
https://www.ros.org/reps/rep-2000.html#eloquent-elusor-november-2019-november-2020

related: https://github.com/Tiryoh/ros2_setup_scripts_ubuntu/pull/17